### PR TITLE
feat: Improved rules regarding treasure chests by providing clarifica…

### DIFF
--- a/tutorial.txt
+++ b/tutorial.txt
@@ -8,10 +8,12 @@ drag to place or remove marks.
 The numbers on the rows and columns indicate the number
 of walls on that column or row.
 #sprite/tut0.png
-A treasure chest is always in a 3x3 empty room with exactly
-ONE entrance. The chest can appear in ANY of the 3x3 tiles
-in that room. (Yes, a treasure chest can appear directly
-in the entrance)
+Each treasure room contains a single chest in a 3x3 grid of
+walkable tiles and has a single entry point located
+orthogonally adjacent and outside the treasure room. The
+treasure room must be fully enclosed by walls or the map
+border on all orthogonally surrounding sides, except for
+the designated entry point, which must be an empty tile.
 #sprite/tut2.png
 Any "dead-end" (a tile with three walls surrounding it,
 including borders) MUST contain a monster. 

--- a/tutorial_raw.txt
+++ b/tutorial_raw.txt
@@ -4,7 +4,7 @@ This game is similar to picross with a few twists.
 
 The numbers on the rows and columns indicate the number of walls on that column or row. 
 
-A treasure chest is always in a 3x3 empty room with exactly ONE entrance. The chest can appear in ANY of the 3x3 tiles in that room. (Yes, a treasure chest can appear directly in the entrance)
+Each treasure room contains a single chest in a 3x3 grid of walkable tiles and has a single entry point located orthogonally adjacent and outside the treasure room. The treasure room must be fully enclosed by walls or the map border on all orthogonally surrounding sides, except for the designated entry point, which must be an empty tile.
 
 Any "dead-end" (a tile with three walls surrounding it, including borders) MUST contain a monster. A dead-end can't exist without a monster.
 


### PR DESCRIPTION
…tion and removing ambiguities.

Original Treasure Chest Rules:
A treasure chest is always in a 3x3 empty room with exactly ONE entrance. The chest can appear in ANY of the 3x3 tiles in that room. (Yes, a treasure chest can appear directly in the entrance)

Original Ambiguity #1: Counter-intuitive that a tile in the room is considered the entrance. It would be clearer to treat the empty tile orthogonally adjacent to the room as the entrance. Original Ambiguity #2: Based on the previous text, it seems possible for a treasure room to contain more than one chest, but this should not be the case. Treasure rooms should only contain exactly one chest. Original Ambiguity #3: Based on the current entrance definition, this might be a valid setup, but it shouldn't be (1 = entrance, 0 = empty tile, X = Wall): XXX0XXXX
X001100X
X000000X
X000000X
XXXXXXXX
(two connected treasure rooms). This should not be possible though.

Proposal S:
Each treasure room contains a single chest in a 3x3 grid of walkable tiles and has a single entry point located orthogonally adjacent and outside the treasure room. The treasure room must be fully enclosed by walls or the map border on all orthogonally surrounding sides, except for the designated entry point, which must be an empty tile.

Proposal S Notes:
- Addresses Counter-intuitive entrance: Proposal S specifies that the entry point should be located orthogonally adjacent and outside the treasure room, providing a clearer definition of the entrance location.
- Addresses Multiple chests in a treasure room: Proposal S explicitly states that each treasure room contains a single chest, eliminating the possibility of multiple chests within a room.
- Addresses Validity of treasure room connections: Proposal S implicitly restricts the formation of connected treasure rooms by emphasizing the need for full enclosure by walls or the map border on all orthogonally surrounding sides.